### PR TITLE
Configurable permission message upgrades

### DIFF
--- a/Spigot-API-Patches/0162-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-API-Patches/0162-Make-the-default-permission-message-configurable.patch
@@ -43,15 +43,22 @@ index da9c85372605ab0d68f21bb38885eb0f4dfebded..47e6a3f2bd41a9a01ec74e4c3f491909
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index 7c80dc54776d0d66f7816b77136f6dbd9b801704..c10fc8d2386301bc2caddcdb1cd18566bcaa8689 100644
+index 7c80dc54776d0d66f7816b77136f6dbd9b801704..850a5f0dbe0818a7268b461b05995323b43b5d3b 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
-@@ -185,7 +185,7 @@ public abstract class Command {
+@@ -184,9 +184,13 @@ public abstract class Command {
+             return true;
          }
  
++        // Paper start
++        String permissionMessage = this.permissionMessage;
          if (permissionMessage == null) {
 -            target.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is a mistake.");
-+            target.sendMessage(Bukkit.getPermissionMessage()); // Paper
-         } else if (permissionMessage.length() != 0) {
+-        } else if (permissionMessage.length() != 0) {
++            permissionMessage = Bukkit.getPermissionMessage();
++        }
++        if (permissionMessage.length() != 0) {
++        // Paper end
              for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
                  target.sendMessage(line);
+             }


### PR DESCRIPTION
This allows the configurable permission message in paper.yml to be blank and also support newlines